### PR TITLE
explicitly using aws config in boto

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 import qrcode
 import boto3
+import os
 from io import BytesIO
 
 # Loading Environment variable (AWS Access Key and Secret Key)
@@ -23,7 +24,11 @@ app.add_middleware(
 )
 
 # AWS S3 Configuration
-s3 = boto3.client('s3')
+s3 = boto3.client(
+    's3',
+    aws_access_key_id= os.getenv("AWS_ACCESS_KEY"),
+    aws_secret_access_key= os.getenv("AWS_SECRET_KEY"))
+
 bucket_name = 'YOUR_BUCKET_NAME' # Add your bucket name here
 
 @app.post("/generate-qr/")


### PR DESCRIPTION
This fixes #4 
I had to explicitly use the Secrets in the boto3 initialization.
```
s3 = boto3.client(
    's3',
    aws_access_key_id= os.getenv("AWS_ACCESS_KEY"),
    aws_secret_access_key= os.getenv("AWS_SECRET_KEY"))
```

Based on the [AWS documentation.](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#guide-credentials)

Also, make sure the bucket name is set in the `main.py`.

Tested the API locally.
<img width="737" alt="Screenshot 2024-07-30 at 8 56 24 AM" src="https://github.com/user-attachments/assets/8f18341c-fad8-439e-ba04-fba64660182b">
<img width="952" alt="Screenshot 2024-07-30 at 8 56 35 AM" src="https://github.com/user-attachments/assets/727a7f0b-1594-46a6-a168-68e1eb513a3e">
