### PR TITLE
Add Azure Blob Storage support alongside AWS S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ The API code exists in the `api` directory. You can run the API server locally:
 - Make sure you are in the `api` directory
 - Create a virtualenv by typing in the following command: `python -m venv .venv`
 - Install the required packages: `pip install -r requirements.txt`
-- Create a `.env` file, and add you AWS Access and Secret key, check  `.env.example`
-- Also, change the BUCKET_NAME to your S3 bucket name in `main.py`
+- Create a `.env` file, and add your AWS Access and Secret key for AWS or Azure Storage Connection string for Azure, check  `.env.example`
+- Set `CLOUD_PROVIDER` to `AWS` or `AZURE` accordingly in the .env
+- Also, change the BUCKET_NAME to your S3 bucket name in `main.py` (Similarly container name for Azure Storage)
 - Run the API server: `uvicorn main:app --reload`
 - Your API Server should be running on port `http://localhost:8000`
 

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,2 +1,4 @@
 AWS_ACCESS_KEY=Your-AWS-Access-Key
 AWS_SECRET_KEY=Your-AWS-Secret-Access-Key
+AZURE_STORAGE_CONNECTION_STRING=Your-Azure-Storage-Connection-String
+CLOUD_PROVIDER=AWS

--- a/api/main.py
+++ b/api/main.py
@@ -4,6 +4,7 @@ import qrcode
 import boto3
 import os
 from io import BytesIO
+from azure.storage.blob import BlobServiceClient, ContentSettings
 
 # Loading Environment variable (AWS Access Key and Secret Key)
 from dotenv import load_dotenv
@@ -23,14 +24,32 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# AWS S3 Configuration
-s3 = boto3.client(
-    's3',
-    aws_access_key_id= os.getenv("AWS_ACCESS_KEY"),
-    aws_secret_access_key= os.getenv("AWS_SECRET_KEY"))
+# Supported Options - AWS/AZURE (Default: AWS)
+CLOUD_PROVIDER = os.getenv("CLOUD_PROVIDER")
 
-bucket_name = 'YOUR_BUCKET_NAME' # Add your bucket name here
+if CLOUD_PROVIDER == "AZURE":
+    # Azure Blob Storage Configuration
+    """    
+    Create a Storage Account and container in Azure
+    Ensure anonymous access is available for blob containers (Settings > Configuration > Allow Blob anonymous access)
+    Enable anonymous access (Select the blob container > Change Access Level > Blob)
+    Edit the container name below and add the connection string in the .env (Found in Access Keys of the Storage Account)
+    """
 
+    connection_string = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
+    container_name = 'qrcodes'  # Add your container name here
+
+    blob_service_client = BlobServiceClient.from_connection_string(connection_string)
+    container_client = blob_service_client.get_container_client(container_name)
+else:
+    # AWS S3 Configuration
+    s3 = boto3.client(
+        's3',
+        aws_access_key_id= os.getenv("AWS_ACCESS_KEY"),
+        aws_secret_access_key= os.getenv("AWS_SECRET_KEY"))
+
+    bucket_name = 'YOUR_BUCKET_NAME' # Add your bucket name here
+    
 @app.post("/generate-qr/")
 async def generate_qr(url: str):
     # Generate QR Code
@@ -54,12 +73,25 @@ async def generate_qr(url: str):
     file_name = f"qr_codes/{url.split('//')[-1]}.png"
 
     try:
-        # Upload to S3
-        s3.put_object(Bucket=bucket_name, Key=file_name, Body=img_byte_arr, ContentType='image/png', ACL='public-read')
-        
-        # Generate the S3 URL
-        s3_url = f"https://{bucket_name}.s3.amazonaws.com/{file_name}"
-        return {"qr_code_url": s3_url}
+        if CLOUD_PROVIDER == "AZURE":
+           # Upload to Azure Blob Storage
+            blob_client = container_client.get_blob_client(file_name)
+            
+            # Use ContentSettings to specify content type
+            content_settings = ContentSettings(content_type="image/png")
+            
+            blob_client.upload_blob(img_byte_arr, blob_type="BlockBlob", content_settings=content_settings, overwrite=True)
+            
+            # Generate the Blob URL
+            blob_url = f"https://{blob_service_client.account_name}.blob.core.windows.net/{container_name}/{file_name}"
+            return {"qr_code_url": blob_url}
+        else:
+             # Upload to S3
+            s3.put_object(Bucket=bucket_name, Key=file_name, Body=img_byte_arr, ContentType='image/png', ACL='public-read')
+            
+            # Generate the S3 URL
+            s3_url = f"https://{bucket_name}.s3.amazonaws.com/{file_name}"
+            return {"qr_code_url": s3_url}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
     

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,5 +1,6 @@
 annotated-types==0.6.0
 anyio==3.7.1
+azure-storage-blob==12.23.1
 boto3==1.34.11
 botocore==1.34.11
 click==8.1.7


### PR DESCRIPTION
- Added support for uploading QRs to Azure Blob Storage.
- Can easily toggle between AWS and Azure by configuring the `CLOUD_PROVIDER` variable in .env (Defaults to AWS)